### PR TITLE
trim and refactor

### DIFF
--- a/app/components/comment-composer.tsx
+++ b/app/components/comment-composer.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useComments } from "~/lib/use-comments";
 
 interface Props {
@@ -6,6 +7,7 @@ interface Props {
 
 export function CommentComposer({ taskId }: Props) {
 	const { create } = useComments(taskId);
+	const inputRef = React.useRef<HTMLTextAreaElement>(null);
 
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
@@ -17,6 +19,7 @@ export function CommentComposer({ taskId }: Props) {
 
 		create.mutate({ taskId, content: content.trim(), author: "notgr" });
 		form.reset();
+		inputRef.current?.focus();
 	};
 
 	return (
@@ -34,6 +37,7 @@ export function CommentComposer({ taskId }: Props) {
 				placeholder="Add a comment"
 				name="content"
 				rows={3}
+				ref={inputRef}
 			/>
 
 			<div className="text-sm text-secondary flex justify-between gap-4">
@@ -44,7 +48,7 @@ export function CommentComposer({ taskId }: Props) {
 
 				<button
 					type="submit"
-					className="flex gap-2 items-center bg-stone-300/60 px-2 rounded-full"
+					className="flex gap-2 items-center bg-stone-300/60 dark:bg-neutral-700 px-2 rounded-full"
 				>
 					<div className="i-solar-command-linear" /> + Enter to send
 				</button>

--- a/app/components/menus/status-menu.tsx
+++ b/app/components/menus/status-menu.tsx
@@ -1,54 +1,53 @@
-import React from "react";
-import type { Status } from "@prisma/client";
+import type { Status, Task } from "@prisma/client";
 import clsx from "clsx";
+import React from "react";
+import { usePopoverContext } from "../popover";
 
 interface StatusMenuProps {
-	status: string;
-	onStatusSelect: (status: Status) => void;
+	task: Task;
+	onStatusUpdate: (status: Status) => void;
 	onDelete: () => void;
 }
 
 interface StatusProps {
-	name: Status;
+	id: Status;
 	label: string;
 	icon: string;
 }
 
 const statuses: StatusProps[] = [
 	{
-		name: "pending",
+		id: "pending",
 		label: "Pending",
 		icon: "i-lucide-circle text-secondary",
 	},
 	{
-		name: "inProgress",
+		id: "inProgress",
 		label: "In Progress",
 		icon: "i-lucide-loader-circle text-amber-500",
 	},
 	{
-		name: "done",
+		id: "done",
 		label: "Done",
 		icon: "i-solar-check-circle-bold text-indigo-500",
 	},
 ];
 
-export function StatusMenu({
-	onStatusSelect,
-	status,
-	onDelete,
-}: StatusMenuProps) {
+export function StatusMenu({ task, onDelete, onStatusUpdate }: StatusMenuProps) {
 	const [confirmingDelete, setConfirmingDelete] = React.useState(false);
+
+	const popover = usePopoverContext();
+
+	function handleUpdate(status: Status) {
+		popover.setOpen(false);
+		onStatusUpdate(status);
+	}
 
 	function handleDeleteClick(e: React.MouseEvent) {
 		e.stopPropagation();
-
-		if (confirmingDelete) {
-			onDelete();
-			return;
-		}
-
 		setConfirmingDelete(true);
 	}
+
 
 	function cancelDelete(e: React.MouseEvent) {
 		e.stopPropagation();
@@ -58,9 +57,7 @@ export function StatusMenu({
 	return (
 		<div className="bg-neutral-100 text-sm dark:bg-neutral-900 rounded-lg w-12.5rem border dark:border-neutral-800 overflow-hidden shadow-lg mt-1.5">
 			<header className="px-2 py-2.5 flex items-center justify-start">
-				<div className="font-semibold ms-2 text-secondary">
-					Change status...
-				</div>
+				<div className="font-medium ms-2 text-secondary">Change status...</div>
 			</header>
 
 			<hr className="dark:border-neutral-800" />
@@ -68,11 +65,12 @@ export function StatusMenu({
 			<ul className="space-y-1 p-1">
 				{statuses.map((s) => (
 					<li
-						key={s.name}
+						key={s.id}
 						className={clsx(
 							"flex items-center pl-3 rounded-lg  hover:bg-neutral-200/80 dark:hover:bg-neutral-800/20",
 							{
-								"bg-neutral-200/80 dark:bg-neutral-800/20": s.name === status,
+								"bg-neutral-200/80 dark:bg-neutral-800/20":
+									s.id === task.status,
 							},
 						)}
 					>
@@ -83,17 +81,19 @@ export function StatusMenu({
 							className="w-full flex items-center justify-between py-2 px-3 bg-transparent font-mono"
 							onClick={(e) => {
 								e.stopPropagation();
-								onStatusSelect(s.name);
+								handleUpdate(s.id);
 							}}
 						>
 							<span>{s.label}</span>
-							{s.name === status && <div className="i-lucide-check size-5" />}
+							{s.id === task.status && (
+								<div className="i-lucide-check text-secondary" />
+							)}
 						</button>
 					</li>
 				))}
 			</ul>
 
-			<div className="font-semibold ms-3 px-1.5 text-secondary">Actions</div>
+			<div className="font-medium ms-3 px-1.5 text-secondary">Actions</div>
 
 			<ul className="space-y-1 p-1">
 				<li className="font-mono">
@@ -107,7 +107,7 @@ export function StatusMenu({
 								<button
 									type="button"
 									className="i-lucide-check w-5 h-5 text-red-500 animate-fade-in"
-									onClick={handleDeleteClick}
+									onClick={onDelete}
 								/>
 								<button
 									type="button"
@@ -122,7 +122,7 @@ export function StatusMenu({
 							className="w-full text-red-500 rounded-lg flex gap-2 items-center bg-transparent py-2 px-3 hover:bg-red-100 dark:hover:bg-red-800/10"
 							onClick={handleDeleteClick}
 						>
-							<div className="i-solar-trash-bin-trash-bold" />
+							<div className="i-solar-trash-bin-trash-linear" />
 							Delete
 						</button>
 					)}

--- a/app/components/status.tsx
+++ b/app/components/status.tsx
@@ -1,42 +1,26 @@
 import clsx from "clsx";
-import { Popover, PopoverContent, PopoverTrigger } from "./popover";
-import { StatusMenu } from "./menus/status-menu";
 import type { Task } from "~/lib/types";
-import { useTasks } from "~/lib/use-tasks";
-import React from "react";
+import { useTaskDelete } from "~/lib/use-task-delete";
+import { useTaskUpdate } from "~/lib/use-task-update";
+import { StatusMenu } from "./menus/status-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
 interface StatusProps {
 	task: Task;
 }
 
+const StatusIcons: Record<Task["status"], string> = {
+	pending: "i-lucide-circle text-secondary",
+	inProgress: "i-lucide-loader-circle text-amber-500",
+	done: "i-solar-check-circle-linear text-stone-400 dark:text-neutral-700",
+};
+
 function Status({ task }: StatusProps) {
-	const [isOpen, setisOpen] = React.useState(false);
-
-	const { update, remove } = useTasks();
-
-	const handleUpdate = (taskId: number, updates: Partial<Task>) => {
-		update.mutate(
-			{ taskId, updates },
-			{
-				onSuccess: () => {
-					setisOpen(false);
-				},
-			},
-		);
-	};
-
-	const handleDelete = (taskId: number) => {
-		remove.mutate(taskId);
-	};
-
-	const StatusIcons: Record<Task["status"], string> = {
-		pending: "i-lucide-circle text-secondary",
-		inProgress: "i-lucide-loader-circle text-amber-500",
-		done: "i-solar-check-circle-linear text-stone-400 dark:text-neutral-700",
-	};
+	const update = useTaskUpdate(task);
+	const remove = useTaskDelete(task);
 
 	return (
-		<Popover open={isOpen} onOpenChange={setisOpen} placement="bottom-start">
+		<Popover placement="bottom-start">
 			<PopoverTrigger asChild>
 				<button
 					data-status-button
@@ -44,28 +28,19 @@ function Status({ task }: StatusProps) {
 					className={clsx(
 						"rounded-full bg-transparent flex items-center justify-center",
 					)}
-					onClick={(e) => {
-						e.stopPropagation();
-						setisOpen(!isOpen);
-					}}
-					onKeyDown={(e) => {
-						e.stopPropagation();
-						if (e.key === "Enter" || e.key === " ") {
-							e.preventDefault();
-							setisOpen(!isOpen);
-						}
-					}}
 				>
-					<div className={clsx(StatusIcons[task.status], "size-5")} />
+					<div
+						className={clsx(StatusIcons[task.status], "size-5", {
+							"i-svg-spinners-270-ring": update.status === "pending",
+						})}
+					/>
 				</button>
 			</PopoverTrigger>
 			<PopoverContent className="z-50 popover-content">
 				<StatusMenu
-					status={task.status}
-					onStatusSelect={(newStatus) =>
-						handleUpdate(task.id, { status: newStatus })
-					}
-					onDelete={() => handleDelete(task.id)}
+					task={task}
+					onStatusUpdate={(status) => update.mutate({ status })}
+					onDelete={() => remove.mutate()}
 				/>
 			</PopoverContent>
 		</Popover>

--- a/app/components/task-comments.tsx
+++ b/app/components/task-comments.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export function TaskComments({ opened, taskId }: Props) {
-	const { data: comments = [], remove } = useComments(taskId);
+	const { data: comments = [], remove } = useComments(taskId, opened);
 
 	if (!opened) return null;
 

--- a/app/components/task-composer.tsx
+++ b/app/components/task-composer.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { useTasks } from "~/lib/use-tasks";
 
 export function TaskComposer() {
-	const [inProgress, setInProgress] = React.useState(false);
-
 	const formRef = React.useRef<HTMLFormElement>(null);
 	const inputRef = React.useRef<HTMLInputElement>(null);
 
@@ -17,17 +15,13 @@ export function TaskComposer() {
 
 		if (!title.trim()) return;
 
-		setInProgress(true);
-
 		create.mutate(
-			{ title, assignee: "notgr", author: "notgr" },
+			{ title: title.trim(), assignee: "notgr", author: "notgr" },
 			{
 				onSuccess: () => {
 					formRef.current?.reset();
-					inputRef.current?.focus();
-				},
-				onSettled: () => {
-					setInProgress(false);
+					// wait enough for the disabled prop to be removed
+					setTimeout(() => inputRef.current?.focus(), 100);
 				},
 			},
 		);
@@ -48,7 +42,7 @@ export function TaskComposer() {
 				placeholder="What needs done?"
 				name="title"
 				className="w-full font-medium bg-transparent border-none outline-none focus:outline-none focus:ring-0 p-0"
-				disabled={inProgress}
+				disabled={create.isPending}
 				ref={inputRef}
 			/>
 		</form>

--- a/app/components/todos.tsx
+++ b/app/components/todos.tsx
@@ -1,13 +1,13 @@
+import { useTasks } from "~/lib/use-tasks";
+import { LoadingButton } from "./loading-button";
 import { TaskComposer } from "./task-composer";
 import { TodoItem } from "./todo-item";
-import { useTasks } from "~/lib/use-tasks";
-import type { Task } from "@prisma/client";
-import { LoadingButton } from "./loading-button";
 
 export function Todos() {
-	const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useTasks();
+	const { query } = useTasks();
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = query;
 
-	const tasks = data?.pages.flatMap((p) => p.tasks) ?? [];
+	const tasks = data?.pages.flat()
 
 	return (
 		<div className="overflow-y-auto h-full">
@@ -16,7 +16,7 @@ export function Todos() {
 					<TaskComposer />
 				</li>
 
-				{tasks.map((task) => (
+				{tasks?.map((task) => (
 					<li key={task.id}>
 						<TodoItem task={task} />
 					</li>

--- a/app/lib/use-comments.ts
+++ b/app/lib/use-comments.ts
@@ -44,13 +44,13 @@ export async function createComment({
 	return data.comment;
 }
 
-export function useComments(taskId: number) {
+export function useComments(taskId: number, enabled = false) {
 	const queryClient = useQueryClient();
 
 	const query = useQuery({
 		queryKey: ["comments", taskId],
 		queryFn: () => fetchComments(taskId),
-		enabled: !!taskId,
+		enabled: !!taskId && enabled,
 	});
 
 	const create = useMutation({

--- a/app/lib/use-task-delete.ts
+++ b/app/lib/use-task-delete.ts
@@ -1,0 +1,23 @@
+import type { Task } from "@prisma/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useTaskDelete(task: Task) {
+	const queryClient = useQueryClient();
+
+	const remove = useMutation({
+		mutationFn: () => deleteTask(task.id),
+		onSuccess: async () => {
+			return await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+		},
+	});
+
+	return remove;
+}
+
+export async function deleteTask(taskId: number): Promise<void> {
+	await fetch("/list", {
+		method: "DELETE",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ taskId }),
+	});
+}

--- a/app/lib/use-task-update.ts
+++ b/app/lib/use-task-update.ts
@@ -1,0 +1,36 @@
+import type { Task } from "@prisma/client";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useTaskUpdate(task: Task) {
+	const queryClient = useQueryClient();
+
+	const update = useMutation({
+		mutationKey: ["task", task.id],
+		mutationFn: async (updates: Partial<Task>) => {
+			return await updateTaskRequest({ taskId: task.id, updates });
+		},
+		onSuccess: async () => {
+			return await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+		},
+	});
+
+	return update;
+}
+
+export async function updateTaskRequest({
+	taskId,
+	updates,
+}: {
+	taskId: number;
+	updates: Partial<Task>;
+}): Promise<Task> {
+	const res = await fetch("/list", {
+		method: "PATCH",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ taskId, ...updates }),
+	});
+
+	const data = await res.json();
+
+	return data.task;
+}

--- a/app/lib/use-tasks.ts
+++ b/app/lib/use-tasks.ts
@@ -12,7 +12,8 @@ export function useTasks() {
 	const tasksQuery = useInfiniteQuery({
 		queryKey: ["tasks"],
 		queryFn: fetchTasks,
-		getNextPageParam: (_, pages) => pages.length,
+		getNextPageParam: (lastPage, pages) =>
+			lastPage.length === 0 ? undefined : pages.length,
 		initialPageParam: 0,
 		staleTime: 1000 * 60 * 5,
 	});

--- a/app/lib/use-tasks.ts
+++ b/app/lib/use-tasks.ts
@@ -6,29 +6,47 @@ import {
 } from "@tanstack/react-query";
 import type { Task } from "./types";
 
-interface PaginatedTasks {
-	tasks: Task[];
-	nextPage?: number;
+export function useTasks() {
+	const queryClient = useQueryClient();
+
+	const tasksQuery = useInfiniteQuery({
+		queryKey: ["tasks"],
+		queryFn: fetchTasks,
+		getNextPageParam: (_, pages) => pages.length,
+		initialPageParam: 0,
+		staleTime: 1000 * 60 * 5,
+	});
+
+	const create = useMutation({
+		mutationFn: createTask,
+		onSuccess: (newTask) => {
+			type Old = { pageParams: number[]; pages: Task[][] };
+			queryClient.setQueryData(["tasks"], (old?: Old) => {
+				if (!old) return;
+
+				const [top, ...rest] = old.pages;
+
+				return {
+					pageParams: old.pageParams,
+					pages: [[newTask, ...top], ...rest],
+				};
+			});
+		},
+		onError: (err) => {
+			console.error(err);
+		},
+	});
+
+	return { query: tasksQuery, create };
 }
 
 export async function fetchTasks({
 	pageParam = 0,
-}: QueryFunctionContext): Promise<PaginatedTasks> {
+}: QueryFunctionContext): Promise<Task[]> {
 	const res = await fetch(`/list?page=${pageParam as number}`);
 	const data = await res.json();
 
-	return {
-		tasks: data.tasks,
-		nextPage: data.tasks.length > 0 ? (pageParam as number) + 1 : undefined,
-	};
-}
-
-export async function deleteTask(taskId: number): Promise<void> {
-	await fetch("/list", {
-		method: "DELETE",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ taskId }),
-	});
+	return data.tasks;
 }
 
 export async function createTask(task: Partial<Task>): Promise<Task> {
@@ -41,113 +59,4 @@ export async function createTask(task: Partial<Task>): Promise<Task> {
 	const data = await res.json();
 
 	return data.task;
-}
-
-export async function updateTaskRequest({
-	taskId,
-	updates,
-}: {
-	taskId: number;
-	updates: Partial<Task>;
-}): Promise<Task> {
-	const res = await fetch("/list", {
-		method: "PATCH",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ taskId, ...updates }),
-	});
-
-	const data = await res.json();
-
-	return data.task;
-}
-
-export function useTasks() {
-	const queryClient = useQueryClient();
-
-	const tasksQuery = useInfiniteQuery<PaginatedTasks>({
-		queryKey: ["tasks"],
-		queryFn: fetchTasks,
-		getNextPageParam: (lastPage) => lastPage.nextPage,
-		initialPageParam: 0,
-	});
-
-	const create = useMutation({
-		mutationFn: createTask,
-		onSuccess: (newTask) => {
-			queryClient.setQueryData(["tasks"], (old: any) => {
-				if (!old) return old;
-
-				return {
-					...old,
-					pages: old.pages.map((page: any, index: number) =>
-						index === 0 ? { ...page, tasks: [newTask, ...page.tasks] } : page,
-					),
-				};
-			});
-		},
-	});
-
-	const update = useMutation({
-		mutationFn: updateTaskRequest,
-
-		onMutate: async ({ taskId, updates }) => {
-			await queryClient.cancelQueries({ queryKey: ["tasks"] });
-
-			const previous = queryClient.getQueryData(["tasks"]);
-
-			queryClient.setQueryData(["tasks"], (old: any) => ({
-				...old,
-				pages: old.pages.map((page: any) => ({
-					...page,
-					tasks: page.tasks.map((t: Task) =>
-						t.id === taskId ? { ...t, ...updates } : t,
-					),
-				})),
-			}));
-
-			return { previous };
-		},
-
-		onError: (_err, _variables, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(["tasks"], context.previous);
-			}
-		},
-
-		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: ["tasks"] });
-		},
-	});
-
-	const remove = useMutation({
-		mutationFn: deleteTask,
-
-		onMutate: async (taskId: number) => {
-			await queryClient.cancelQueries({ queryKey: ["tasks"] });
-
-			const previous = queryClient.getQueryData(["tasks"]);
-
-			queryClient.setQueryData(["tasks"], (old: any) => ({
-				...old,
-				pages: old.pages.map((page: any) => ({
-					...page,
-					tasks: page.tasks.filter((t: Task) => t.id !== taskId),
-				})),
-			}));
-
-			return { previous };
-		},
-
-		onError: (_err, taskId, context) => {
-			if (context?.previous) {
-				queryClient.setQueryData(["tasks"], context.previous);
-			}
-		},
-
-		onSettled: () => {
-			queryClient.invalidateQueries({ queryKey: ["tasks"] });
-		},
-	});
-
-	return { ...tasksQuery, create, update, remove };
 }


### PR DESCRIPTION
- When you add a task, `fetchTasks` was being called anyways, so the `onSuccess` callback was redundant.
- Now, the reason it was being called had to do with the `staleTime` config.
- Then when you mutated an item on the list, the whole list (and paginations still refreshed)

This means, there was little need for the custom logic in `onSuccess`, `onMutate`, etc.

Also trimmed code in some other places and refactored others